### PR TITLE
Fix for the broken search

### DIFF
--- a/components/utils/ShapeList.js
+++ b/components/utils/ShapeList.js
@@ -517,13 +517,6 @@ const ShapeList = ({
             />
           ) : (
             filteredShape.map((shape, index) => {
-              /*setTimeout(() => {
-                if (isDoubleTaped[shape.id]) {
-                  setIsDoubleTaped({
-                    [shape.id]: false
-                  });
-                }
-              }, 2000);*/
               return (
                 <React.Fragment key={index}>
                   <ShapeCard {...shape['double-tap-bind']}>

--- a/components/utils/ShapeList.js
+++ b/components/utils/ShapeList.js
@@ -279,6 +279,10 @@ const ShapeList = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [shapeToDelete, setShapeToDelete] = useState();
 
+  // Double Tab Shape
+  const [isDoubleTaped, setIsDoubleTaped] = useState(false);
+
+
   useEffect(() => {
     const copy = [...shapes];
     if (sort === "recent") {
@@ -493,22 +497,20 @@ const ShapeList = ({
             />
           ) : (
             filteredShape.map((shape, index) => {
-              const [isDoubleTaped, setIsDoubleTaped] = useState(false);
-
-              const bind = useDoubleTap((event) => {
+              /*const bind = useDoubleTap((event) => {
                 // Your action here
                 performLike(event, shape["shape_id"]);
 
                 // showing ui changes
-                setIsDoubleTaped(true);
+                //setIsDoubleTaped(true);
                 setTimeout(() => {
                   setIsDoubleTaped(false);
                 }, 2000);
-              });
+              });*/
 
               return (
                 <React.Fragment key={index}>
-                  <ShapeCard {...bind}>
+                  <ShapeCard>
                     <ShapeCardBody>
                       {isDoubleTaped && (
                         <DoubleTapLike>

--- a/components/utils/ShapeList.js
+++ b/components/utils/ShapeList.js
@@ -249,6 +249,30 @@ const ShapeList = ({
   shapeAction,
   setShapeAction,
 }) => {
+  // Double Tab Shape
+  const [isDoubleTaped, setIsDoubleTaped] = useState({});
+
+  const bindShapesWithDoubleTab = (shapes) => {
+    const modifiedShapes = shapes.map((shape, index) => {
+      const bind = useDoubleTap((event) => {
+        setIsDoubleTaped({
+          ...isDoubleTaped, 
+          [shape.shape_id]: true,
+        });
+        setTimeout(() => {
+          setIsDoubleTaped({
+            ...isDoubleTaped, 
+            [shape.shape_id]: false,
+          });
+        }, 2000);
+        performLike(event, shape["shape_id"]);
+      });
+      shape['double-tap-bind'] = bind;
+      return shape;
+    });
+    return modifiedShapes;
+  }
+
   const filterShape = (shapes, searchTerm) => {
     if (!searchTerm) {
       return shapes;
@@ -261,7 +285,7 @@ const ShapeList = ({
   // All shapes
   const [shapes, setShapes] = useState(data);
   // filtered shapes as state
-  const [filteredShape, setFilteredShape] = useState(shapes);
+  const [filteredShape, setFilteredShape] = useState(bindShapesWithDoubleTab(shapes));
 
   // All about export shape states
   const [showExportModal, setShowExportModal] = useState(false);
@@ -278,10 +302,6 @@ const ShapeList = ({
   // All about editing private shapes
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [shapeToDelete, setShapeToDelete] = useState();
-
-  // Double Tab Shape
-  const [isDoubleTaped, setIsDoubleTaped] = useState(false);
-
 
   useEffect(() => {
     const copy = [...shapes];
@@ -497,22 +517,18 @@ const ShapeList = ({
             />
           ) : (
             filteredShape.map((shape, index) => {
-              /*const bind = useDoubleTap((event) => {
-                // Your action here
-                performLike(event, shape["shape_id"]);
-
-                // showing ui changes
-                //setIsDoubleTaped(true);
-                setTimeout(() => {
-                  setIsDoubleTaped(false);
-                }, 2000);
-              });*/
-
+              /*setTimeout(() => {
+                if (isDoubleTaped[shape.id]) {
+                  setIsDoubleTaped({
+                    [shape.id]: false
+                  });
+                }
+              }, 2000);*/
               return (
                 <React.Fragment key={index}>
-                  <ShapeCard>
+                  <ShapeCard {...shape['double-tap-bind']}>
                     <ShapeCardBody>
-                      {isDoubleTaped && (
+                      {isDoubleTaped[shape.shape_id] && (
                         <DoubleTapLike>
                           <div id="pop">
                             <LikeFilledIcon


### PR DESCRIPTION
# Issue

This issue was introduced while implementing the double tap-like feature. It was breaking the search as the hook call was failing in rerender once the search takes place.

# Fix

Instead, the logic of useDoubleTap hook gets used in the render, we now handle it in the shape model itself. We recognize if a shape has been double-tapped and then do the needful. The rest of the double-tap logic is kept intact.
