### PR TITLE
Update Landing.js

### DIFF
--- a/components/core/Landing.js
+++ b/components/core/Landing.js
@@ -562,8 +562,8 @@ const Landing = ({ setOpen, user, setUser }) => {
                     </div>
                     <h3 className="card-title">Share</h3>
                     <p className="card-desc">
-                      When you create something fabously great, do share it with the awesome developer
-                      community. TryShape allows you to do that when you make your ceativity public.  
+                      When you create something fabulously great, do share it with the awesome developer
+                      community. TryShape allows you to do that when you make your creativity public.  
                     </p>
                   </FeatureCardItem>
                 </FeatureCards>


### PR DESCRIPTION
Typos in lines 564 and 566 are rectified.
![typos](https://user-images.githubusercontent.com/88289387/193359384-fb1f7fcd-4d70-4765-b748-a751b899b03c.png)
