### PR TITLE
fixed: made No shape found image responsive

### DIFF
--- a/components/utils/NoShapeFound.js
+++ b/components/utils/NoShapeFound.js
@@ -36,7 +36,8 @@ const PageWrapper = styled.div`
     }
 
     img {
-        max-width: 300px;
+        max-width: 100%;
+        height: auto;
     }
 
 `;


### PR DESCRIPTION
I have made the no-shape found image responsive.
Here are the results after fixing the code:
![Before/After](https://user-images.githubusercontent.com/65452005/193392390-23ade839-834a-43e5-aecf-4ca11b295202.png)

When merging, please do add `hacktoberfest-accepted` tag  🙏.
